### PR TITLE
Provide contextual help and “code completion” in application.properties

### DIFF
--- a/zkspringboot-starter/pom.xml
+++ b/zkspringboot-starter/pom.xml
@@ -58,7 +58,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
 		<dependency>
 			<groupId>org.zkoss.zk</groupId>
 			<artifactId>zkbind</artifactId>


### PR DESCRIPTION
Enable IDE autocomplete support when editing the ZK configuration options via `application.properties` 

Use spring-boot-configuration-processor to auto-generate META-INF/spring-configuration-metadata.json
reference : [configuration-metadata](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#configuration-metadata)